### PR TITLE
Update Spectre.Console to 0.38.0

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "cake.tool": {
-      "version": "0.38.4",
+      "version": "1.1.0",
       "commands": [
         "dotnet-cake"
       ]

--- a/build.cake
+++ b/build.cake
@@ -1,3 +1,4 @@
+#module nuget:?package=Cake.BuildSystems.Module&version=3.0.1
 #load "build/helpers.cake"
 #load "build/version.cake"
 #tool "nuget:https://api.nuget.org/v3/index.json?package=nuget.commandline&version=5.3.1"
@@ -81,7 +82,7 @@ Task("Build")
 		};
 		DotNetCoreBuild(project.FullPath, settings);
 	}
-	
+
 });
 
 Task("NuGet")

--- a/build/version.cake
+++ b/build/version.cake
@@ -1,9 +1,8 @@
-#module nuget:?package=Cake.DotNetTool.Module&version=0.4.0
-#tool "dotnet:https://api.nuget.org/v3/index.json?package=minver-cli&version=2.3.0"
-#addin "nuget:?package=Cake.MinVer&version=0.1.0"
+#tool "dotnet:?package=minver-cli&version=2.4.0"
+#addin "nuget:?package=Cake.MinVer&version=1.0.0"
 
 var fallbackVersion = Argument<string>("force-version", EnvironmentVariable("FALLBACK_VERSION") ?? "0.1.0");
- 
+
 string BuildVersion(string fallbackVersion) {
     var PackageVersion = string.Empty;
     try {

--- a/src/Spectre.Cli.Extensions.DependencyInjection/DependencyInjectionRegistrar.cs
+++ b/src/Spectre.Cli.Extensions.DependencyInjection/DependencyInjectionRegistrar.cs
@@ -15,6 +15,7 @@ namespace Spectre.Cli.Extensions.DependencyInjection
             Services = services;
             BuiltProviders = new List<IDisposable>();
         }
+
         public ITypeResolver Build()
         {
             var buildServiceProvider = Services.BuildServiceProvider();
@@ -30,6 +31,11 @@ namespace Spectre.Cli.Extensions.DependencyInjection
         public void RegisterInstance(Type service, object implementation)
         {
             Services.AddSingleton(service, implementation);
+        }
+
+        public void RegisterLazy(Type service, Func<object> factory)
+        {
+            Services.AddSingleton(service, _ => factory());
         }
 
         public void Dispose()

--- a/src/Spectre.Cli.Extensions.DependencyInjection/Spectre.Cli.Extensions.DependencyInjection.csproj
+++ b/src/Spectre.Cli.Extensions.DependencyInjection/Spectre.Cli.Extensions.DependencyInjection.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.9" />
-    <PackageReference Include="Spectre.Console" Version="0.36.0" />
+    <PackageReference Include="Spectre.Console" Version="0.38.0" />
   </ItemGroup>
 
 </Project>

--- a/tools/Modules/packages.config
+++ b/tools/Modules/packages.config
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<packages>
-    <package id="Cake.BuildSystems.Module" version="0.2.0" />
-</packages>


### PR DESCRIPTION
This is a WIP PR to support breaking change in the upcoming Spectre.Console to 0.38.0 release, ITypeRegistrar  now has an new `void RegisterLazy(Type service, Func<object> factory)` method.

Some unrelated maintenance
* Update Cake to 1.1.0
* Remove reference to Cake.DotNetTool.Module (now ships with Cake)
* Update Cake.MinVer 1.0.0
* Update minver-cli to 2.4.0
* Move Cake.BuildSystems.Module from package.config to module directive