### PR TITLE
Minor tweaks to make work with the latest version of Spectre.Cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Once you've installed both `Spectre.Console` and this package, just change the c
 ```csharp
 var services = new ServiceCollection();
 // add extra services to the container here
-using registrar = new DependencyInjectionRegistrar(services);
+using var registrar = new DependencyInjectionRegistrar(services);
 var app = new CommandApp(registrar);
 app.Configure(config =>
 {

--- a/src/Spectre.Cli.Extensions.DependencyInjection/DependencyInjectionRegistrar.cs
+++ b/src/Spectre.Cli.Extensions.DependencyInjection/DependencyInjectionRegistrar.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using Microsoft.Extensions.DependencyInjection;
-using Spectre.Console.Cli;
 
 namespace Spectre.Cli.Extensions.DependencyInjection
 {

--- a/src/Spectre.Cli.Extensions.DependencyInjection/DependencyInjectionResolver.cs
+++ b/src/Spectre.Cli.Extensions.DependencyInjection/DependencyInjectionResolver.cs
@@ -1,6 +1,5 @@
 using System;
 using Microsoft.Extensions.DependencyInjection;
-using Spectre.Console.Cli;
 
 namespace Spectre.Cli.Extensions.DependencyInjection
 {

--- a/src/Spectre.Cli.Extensions.DependencyInjection/Spectre.Cli.Extensions.DependencyInjection.csproj
+++ b/src/Spectre.Cli.Extensions.DependencyInjection/Spectre.Cli.Extensions.DependencyInjection.csproj
@@ -15,7 +15,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.9" />
-    <PackageReference Include="Spectre.Console" Version="0.38.0" />
+    <PackageReference Include="Spectre.Cli" Version="0.49.0" />
+    <PackageReference Include="Spectre.Console" Version="0.44.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Types weren't resolving right, this fixes that.

There was also a typo in the readme.